### PR TITLE
移动端适配和稳定性修复

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,10 +18,6 @@ const nextConfig: NextConfig = {
   // 实验性功能
   experimental: {
     optimizePackageImports: ['lucide-react', '@radix-ui/react-icons'],
-    // 允许通过外网 IP 访问本地开发服务器，消除跨域开发警告
-    allowedDevOrigins: [
-      'http://192.210.187.88:3000'
-    ],
   },
 
   // 服务器外部包配置

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,6 +18,10 @@ const nextConfig: NextConfig = {
   // 实验性功能
   experimental: {
     optimizePackageImports: ['lucide-react', '@radix-ui/react-icons'],
+    // 允许通过外网 IP 访问本地开发服务器，消除跨域开发警告
+    allowedDevOrigins: [
+      'http://192.210.187.88:3000'
+    ],
   },
 
   // 服务器外部包配置

--- a/src/app/components/editor/WatermarkCanvas.tsx
+++ b/src/app/components/editor/WatermarkCanvas.tsx
@@ -216,7 +216,7 @@ export function WatermarkCanvas({
           <div className="flex items-center justify-center min-h-96">
             <canvas
               ref={canvasRef}
-              className="max-w-full max-h-full"
+              className="max-w-full max-h-full touch-none"
               style={{
                 display: isReady && currentImage ? 'block' : 'none',
                 margin: '0 auto'

--- a/src/app/compress/layout.tsx
+++ b/src/app/compress/layout.tsx
@@ -6,7 +6,7 @@ interface CompressLayoutProps {
 
 export default function CompressLayout({ children }: CompressLayoutProps) {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-dvh bg-background">
       <div className="container mx-auto px-4 py-8">
         {children}
       </div>

--- a/src/app/compress/page.tsx
+++ b/src/app/compress/page.tsx
@@ -274,7 +274,7 @@ export default function Compress() {
     : 0;
 
   return (
-    <div className="h-screen flex flex-col">
+    <div className="min-h-dvh flex flex-col">
       {/* Top Navigation */}
       <TopNavigation />
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -120,3 +120,20 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* 移动端适配与安全区域辅助 */
+@layer utilities {
+  .safe-top { padding-top: env(safe-area-inset-top); }
+  .safe-bottom { padding-bottom: env(safe-area-inset-bottom); }
+  .safe-left { padding-left: env(safe-area-inset-left); }
+  .safe-right { padding-right: env(safe-area-inset-right); }
+  .scrollbar-none { scrollbar-width: none; }
+  .scrollbar-none::-webkit-scrollbar { display: none; }
+}
+
+@layer base {
+  html, body { height: 100%; }
+  html { -webkit-text-size-adjust: 100%; }
+  body { -webkit-tap-highlight-color: transparent; }
+  img, video { max-width: 100%; height: auto; }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,6 +53,7 @@ export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1.0,
   themeColor: '#ffffff',
+  viewportFit: 'cover',
 };
 
 export default function RootLayout({
@@ -62,7 +63,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="zh-CN">
-      <body className="font-sans antialiased bg-background text-foreground">
+      <body className="font-sans antialiased bg-background text-foreground overflow-x-hidden">
         <ClientSeo />
 
         {/* 服务端渲染的结构化数据 */}
@@ -103,9 +104,41 @@ export default function RootLayout({
             })
           }}
         />
-        <div className="min-h-screen flex flex-col">
+        {/* 兼容性：为不支持的环境提供 crypto.randomUUID polyfill（优先使用 Web Crypto） */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => {
+  try {
+    const g = globalThis;
+    if (!g.crypto) g.crypto = {};
+    if (typeof g.crypto.randomUUID !== 'function') {
+      const uuidv4 = () => {
+        try {
+          if (g.crypto && typeof g.crypto.getRandomValues === 'function') {
+            const bytes = new Uint8Array(16);
+            g.crypto.getRandomValues(bytes);
+            bytes[6] = (bytes[6] & 0x0f) | 0x40;
+            bytes[8] = (bytes[8] & 0x3f) | 0x80;
+            const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+            return hex.slice(0,8) + '-' + hex.slice(8,12) + '-' + hex.slice(12,16) + '-' + hex.slice(16,20) + '-' + hex.slice(20);
+          }
+        } catch {}
+        let ts = Date.now();
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+          const r = (ts + Math.random() * 16) % 16 | 0;
+          ts = Math.floor(ts / 16);
+          return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+        });
+      };
+      g.crypto.randomUUID = uuidv4;
+    }
+  } catch {}
+})();`
+          }}
+        />
+        <div className="min-h-dvh flex flex-col">
           {/* 头部导航 */}
-          <header className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+          <header className="sticky top-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
             {/* 移动端头部 */}
             <div className="lg:hidden h-16 px-4 flex items-center justify-between">
               <div className="flex items-center space-x-3">

--- a/src/app/lib/stores/imageStore.ts
+++ b/src/app/lib/stores/imageStore.ts
@@ -3,6 +3,7 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { ImageInfo, ProcessingStatus, BatchTask, WatermarkConfig } from '@/app/types';
+import { safeUUID } from '@/lib/utils';
 
 // 图片状态接口
 export interface ImageState {
@@ -68,7 +69,7 @@ export interface ImageState {
 }
 
 // 创建图片ID
-const createImageId = () => crypto.randomUUID();
+const createImageId = () => safeUUID();
 
 // 创建图片信息
 const createImageInfo = (file: File): ImageInfo => ({
@@ -319,9 +320,7 @@ export const useImageStore = create<ImageState>()(
 
       // 创建批量任务
       createBatchTask: (name, imageIds) => {
-        const taskId = typeof window !== 'undefined' && typeof crypto !== 'undefined'
-          ? crypto.randomUUID()
-          : `batch_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+        const taskId = `batch_${safeUUID()}`;
         const state = get();
         const images = state.images.filter(img => imageIds.includes(img.id));
         

--- a/src/app/lib/stores/watermarkStore.ts
+++ b/src/app/lib/stores/watermarkStore.ts
@@ -15,6 +15,7 @@ import {
   PositionMode,
   ProportionData
 } from '../../types';
+import { safeUUID } from '@/lib/utils';
 import {
   calculateProportions,
   convertPixelToProportion,
@@ -91,7 +92,7 @@ const defaultPositionConfig: PositionConfig = {
 
 // 默认水印配置
 const createDefaultWatermarkConfig = (): WatermarkConfig => ({
-  id: crypto.randomUUID(),
+  id: safeUUID(),
   type: 'text',
   scaleMode: 'adaptive',
   position: { ...defaultPositionConfig },
@@ -340,7 +341,7 @@ export const useWatermarkStore = create<WatermarkState>()(
           const state = get();
           return {
             ...state.currentConfig,
-            id: crypto.randomUUID(),
+            id: safeUUID(),
             createdAt: new Date(),
             updatedAt: new Date(),
           };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import { TopNavigation } from '@/components/TopNavigation';
 
 export default function Home() {
   return (
-    <div className="h-screen flex flex-col">
+    <div className="min-h-dvh flex flex-col overflow-hidden">
       {/* JSON-LD 结构化数据 */}
       <StructuredData />
 

--- a/src/components/TopNavigation.tsx
+++ b/src/components/TopNavigation.tsx
@@ -27,7 +27,7 @@ export function TopNavigation() {
     <nav className="border-b bg-background">
       <div className="max-w-6xl mx-auto px-4">
         <div className="flex h-16 items-center justify-center">
-          <div className="flex items-center bg-muted rounded-lg p-1">
+          <div className="flex items-center bg-muted rounded-lg p-1 max-w-full overflow-x-auto">
             {navItems.map((item) => {
               const Icon = item.icon;
               return (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,29 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// 安全的 UUID 生成（兼容不支持 crypto.randomUUID 的环境）
+export function safeUUID(): string {
+  const g: any = globalThis as any;
+  try {
+    if (typeof g?.crypto?.randomUUID === 'function') {
+      return g.crypto.randomUUID();
+    }
+    if (g?.crypto?.getRandomValues) {
+      const bytes = new Uint8Array(16);
+      g.crypto.getRandomValues(bytes);
+      // RFC 4122 version 4
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+    }
+  } catch {}
+  // 最后兜底（Math.random），不保证强随机，仅作 ID 用途
+  let ts = Date.now();
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (ts + Math.random() * 16) % 16 | 0;
+    ts = Math.floor(ts / 16);
+    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+  });
+}

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,33 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+
+// 安全的 UUID 生成（兼容不支持 crypto.randomUUID 的环境）
+export function safeUUID(): string {
+  try {
+    const cryptoObj = (globalThis as unknown as { crypto?: Crypto }).crypto;
+
+    if (typeof cryptoObj?.randomUUID === 'function') {
+      return cryptoObj.randomUUID();
+    }
+    if (typeof cryptoObj?.getRandomValues === 'function') {
+      const bytes = new Uint8Array(16);
+      cryptoObj.getRandomValues(bytes);
+      // RFC 4122 version 4
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+    }
+  } catch {}
+  // 最后兜底（Math.random），不保证强随机，仅作 ID 用途
+  let ts = Date.now();
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (ts + Math.random() * 16) % 16 | 0;
+    ts = Math.floor(ts / 16);
+    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+  });
+}


### PR DESCRIPTION
一个非常棒的项目，但是在手机端上的适配有点一言难尽，希望以下contribution能有所帮助。

>　已经对添加水印的关键功能部分进行了测试，未发现问题。但未进行全面测试，所以在合并之前请**再次全面测试**。

移动端适配                                                                                                                                                 
 - 统一动态高度: 将页面容器从 min-h-screen/h-screen 切换为 min-h-dvh，解决移   动端地址栏/软键盘导致的高度错位                                                   - src/app/layout.tsx:107
      - src/app/page.tsx:12
      - src/app/compress/page.tsx:277
      - src/app/compress/layout.tsx:9
  - 安全区与全局细节：新增安全区工具类与基础移动端规则，避免刘海/底部手势遮
  挡、缩放字体异常、点击高亮
      - src/app/globals.css:124 添加 .safe-*、.scrollbar-none
      - src/app/globals.css:134 设置 html, body 高度、-webkit-text-size-
  adjust、-webkit-tap-highlight-color、图片视频自适应
  - Viewport 与沉浸式：启用 viewportFit: 'cover'
      - src/app/layout.tsx:52
  - 粘性头部：头部改为 sticky top-0 z-50，滚动时导航固定
      - src/app/layout.tsx:109
  - 横向溢出修复：全局 body 禁止横向溢出
      - src/app/layout.tsx:66
  - 导航在小屏可滚：顶栏 pill 容器允许横向滚动，避免换行挤压
      - src/components/TopNavigation.tsx:30
  - 触控优化：编辑画布禁用浏览器默认手势冲突（缩放/滚动）
      - src/app/components/editor/WatermarkCanvas.tsx:219 添加 touch-none

  稳定性修复（UUID）

  - 新增 safeUUID，兼容无 crypto.randomUUID 的环境（优先 randomUUID →
  getRandomValues → Math.random 兜底）
      - src/lib/utils.ts:9
  - 用 safeUUID 替换直接调用
      - src/app/lib/stores/watermarkStore.ts:95、344
      - src/app/lib/stores/imageStore.ts:61、272
  - 浏览器端 polyfill：注入 crypto.randomUUID 运行时补丁，避免旧构建或第三方代
  码仍调用时报错
      - src/app/layout.tsx:110（使用字符串拼接，避免 TSX 模板解析冲突）

